### PR TITLE
 Correct the behaviour when an overlap of mitochondria during then placement is detected

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ We encourage contribution of user-developed extensions that fit within the TOPAS
 4) Build the extensions
 
    Linux:
-        cmake ./ -DTOPAS_EXTENSIONS_DIR=~/topas_extensions/TOPAS-nBio
+        cmake ./ -DTOPAS_EXTENSIONS_DIR=~/topas_extensions/TOPAS-nBio 
         make -j4
+        
    Mac:
-        cmake ./ -DTOPAS_EXTENSIONS_DIR=/Applications/topas_extensions/TOPAS-nBio
+        cmake ./ -DTOPAS_EXTENSIONS_DIR=/Applications/topas_extensions/TOPAS-nBio    
         make -j4
  
 5) Run the demos. For some demos, a pause before quit is enabled, then, write `exit` at the terminal prompt.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ We encourage contribution of user-developed extensions that fit within the TOPAS
 4) Build the extensions
 
    Linux:
-        cmake ./ -DTOPAS_EXTENSIONS_DIR=~/topas_extensions/TOPAS-nBio 
+        cmake ./ -DTOPAS_EXTENSIONS_DIR=~/topas_extensions/TOPAS-nBio    
         make -j4
         
    Mac:

--- a/examples/processes/G4DNAModelPerRegion.txt
+++ b/examples/processes/G4DNAModelPerRegion.txt
@@ -30,8 +30,6 @@ s:Ge/MyCell/Nucleus/Material="G4_WATER"
 s:Ge/MyCell/Nucleus/Color="red"
 s:Ge/MyCell/Nucleus/DrawingStyle="solid"
 d:Ge/MyCell/Nucleus/transNucZ = -5. um
-# Assign this component to world's region
-s:Ge/MyCell/Nucleus/AssignToRegionNamed = "DefaultRegionForTheWorld"
 
 #Mitochondria
 i:Ge/MyCell/Mitochondria/NbOfMito=10
@@ -46,7 +44,7 @@ s:Ge/MyCell/Mitochondria/DrawingStyle="solid"
 # Define condensed-history em model anywhere
 sv:Ph/Default/Modules = 1 "g4em-livermore"
 # But geant4-dna in the G4DNA region. 
-s:Ph/Default/ForRegion/G4DNA/ActiveG4EmModelNamed = "g4em-dna"
+s:Ph/Default/ForRegion/G4DNA/ActiveG4EmModelFromModule = "g4em-dna"
 
 # Shoot few particles
 d:So/Demo/BeamEnergy = 100 MeV

--- a/geometry/cells/TsCuboidalCell.cc
+++ b/geometry/cells/TsCuboidalCell.cc
@@ -16,6 +16,7 @@
 
 #include "TsParameterManager.hh"
 #include "G4VPhysicalVolume.hh"
+#include "G4PhysicalVolumeStore.hh"
 
 #include "G4Box.hh"
 #include "G4Orb.hh"
@@ -173,7 +174,7 @@ G4VPhysicalVolume* TsCuboidalCell::Construct()
                 
                 if (OverlapCheck == false){break;}
                 if (OverlapCheck == true){
-                    pMito = NULL;
+                    G4PhysicalVolumeStore::DeRegister(pMito);
                     G4cout << "**** Finding new position for volume " << subComponentName2 << ":" << j <<  " ****" << G4endl;
                 }
             }

--- a/geometry/cells/TsEllipsoidCell.cc
+++ b/geometry/cells/TsEllipsoidCell.cc
@@ -16,6 +16,7 @@
 
 #include "TsParameterManager.hh"
 #include "G4VPhysicalVolume.hh"
+#include "G4PhysicalVolumeStore.hh"
 
 #include "G4Orb.hh"
 #include "G4Ellipsoid.hh"
@@ -203,7 +204,7 @@ G4VPhysicalVolume* TsEllipsoidCell::Construct()
                 
                 if (OverlapCheck == false){break;}
                 if (OverlapCheck == true){
-                    pMito = NULL;
+                    G4PhysicalVolumeStore::DeRegister(pMito);
                     G4cout << "**** Finding new position for volume " << subComponentName2 << ":" << j <<  " ****" << G4endl;
                 }
             }

--- a/geometry/cells/TsFibroblastCell1.cc
+++ b/geometry/cells/TsFibroblastCell1.cc
@@ -17,6 +17,7 @@
 
 #include "TsParameterManager.hh"
 #include "G4VPhysicalVolume.hh"
+#include "G4PhysicalVolumeStore.hh"
 
 #include "G4TwoVector.hh"
 #include "G4ExtrudedSolid.hh"
@@ -188,7 +189,7 @@ G4VPhysicalVolume* TsFibroblastCell1::Construct()
                 
                 if (OverlapCheck == false){break;}
                 if (OverlapCheck == true){
-                    pMito = NULL;
+                    G4PhysicalVolumeStore::DeRegister(pMito);
                     G4cout << "**** Finding new position for volume " << subComponentName2 << ":" << j <<  " ****" << G4endl;
                 }
             }

--- a/geometry/cells/TsFibroblastCell2.cc
+++ b/geometry/cells/TsFibroblastCell2.cc
@@ -16,6 +16,7 @@
 
 #include "TsParameterManager.hh"
 #include "G4VPhysicalVolume.hh"
+#include "G4PhysicalVolumeStore.hh"
 
 #include "G4TwoVector.hh"
 #include "G4ExtrudedSolid.hh"
@@ -159,7 +160,7 @@ G4VPhysicalVolume* TsFibroblastCell2::Construct()
                 
                 if (OverlapCheck == false){break;}
                 if (OverlapCheck == true){
-                    pMito = NULL;
+                    G4PhysicalVolumeStore::DeRegister(pMito);
                     G4cout << "**** Finding new position for volume " << subComponentName2 << ":" << j <<  " ****" << G4endl;
                 }
             }

--- a/geometry/cells/TsFibroblastCell3.cc
+++ b/geometry/cells/TsFibroblastCell3.cc
@@ -16,6 +16,7 @@
 
 #include "TsParameterManager.hh"
 #include "G4VPhysicalVolume.hh"
+#include "G4PhysicalVolumeStore.hh"
 
 #include "G4TwoVector.hh"
 #include "G4ExtrudedSolid.hh"
@@ -262,7 +263,7 @@ G4VPhysicalVolume* TsFibroblastCell3::Construct()
                 
                 if (OverlapCheck == false){break;}
                 if (OverlapCheck == true){
-                    pMito = NULL;
+                    G4PhysicalVolumeStore::DeRegister(pMito);
                     G4cout << "**** Finding new position for volume " << subComponentName2 << ":" << j <<  " ****" << G4endl;
                 }
             }

--- a/geometry/cells/TsHexagonCell.cc
+++ b/geometry/cells/TsHexagonCell.cc
@@ -17,6 +17,7 @@
 
 #include "TsParameterManager.hh"
 #include "G4VPhysicalVolume.hh"
+#include "G4PhysicalVolumeStore.hh"
 
 #include "G4TwoVector.hh"
 #include "G4ExtrudedSolid.hh"
@@ -188,7 +189,7 @@ G4VPhysicalVolume* TsHexagonCell::Construct()
                 
                 if (OverlapCheck == false){break;}
                 if (OverlapCheck == true){
-                    pMito = NULL;
+                    G4PhysicalVolumeStore::DeRegister(pMito);
                     G4cout << "**** Finding new position for volume " << subComponentName2 << ":" << j <<  " ****" << G4endl;
                 }
             }

--- a/geometry/cells/TsSphericalCell.cc
+++ b/geometry/cells/TsSphericalCell.cc
@@ -16,6 +16,7 @@
 
 #include "TsParameterManager.hh"
 #include "G4VPhysicalVolume.hh"
+#include "G4PhysicalVolumeStore.hh"
 
 #include "G4Orb.hh"
 #include "G4Ellipsoid.hh"
@@ -186,7 +187,7 @@ G4VPhysicalVolume* TsSphericalCell::Construct()
                 
                 if (OverlapCheck == false){break;}
                 if (OverlapCheck == true){
-                    pMito = NULL;
+                    G4PhysicalVolumeStore::DeRegister(pMito);
                     G4cout << "**** Finding new position for volume " << subComponentName2 << ":" << j <<  " ****" << G4endl;
                 }
             }

--- a/geometry/cells/TsSphericalCell.cc
+++ b/geometry/cells/TsSphericalCell.cc
@@ -80,8 +80,8 @@ G4VPhysicalVolume* TsSphericalCell::Construct()
         G4String name1 = GetFullParmName("Nucleus/translateX");
         if (fPm -> ParameterExists(name1)){
             transNucX = fPm->GetDoubleParameter(name1, "Length");
-            if (transNucX > NuclRadius) {
-                G4cerr << "Topas is exiting due to a serious error in geometry setup." << G4endl;
+	    if ((sqrt(transNucX*transNucX)+(transNucY*transNucY)+(transNucZ*transNucZ)) > (CellRadius-NuclRadius)){
+		G4cerr << "Topas is exiting due to a serious error in geometry setup." << G4endl;
                 G4cerr << "Parameter " << name1 << " sets nucleus outside of cell." << G4endl;
                 exit(1);
             }
@@ -90,7 +90,7 @@ G4VPhysicalVolume* TsSphericalCell::Construct()
         name1 = GetFullParmName("Nucleus/translateY");
         if (fPm -> ParameterExists(name1)){
             transNucY = fPm->GetDoubleParameter(name1, "Length");
-            if (transNucY > NuclRadius) {
+            if ((sqrt(transNucX*transNucX)+(transNucY*transNucY)+(transNucZ*transNucZ)) > (CellRadius-NuclRadius)){
                 G4cerr << "Topas is exiting due to a serious error in geometry setup." << G4endl;
                 G4cerr << "Parameter " << name1 << " sets nucleus outside of cell." << G4endl;
                 exit(1);
@@ -100,7 +100,7 @@ G4VPhysicalVolume* TsSphericalCell::Construct()
         name1 = GetFullParmName("Nucleus/translateZ");
         if (fPm -> ParameterExists(name1)){
             transNucZ = fPm->GetDoubleParameter(name1, "Length");
-            if (transNucZ > NuclRadius) {
+            if ((sqrt(transNucX*transNucX)+(transNucY*transNucY)+(transNucZ*transNucZ)) > (CellRadius-NuclRadius)){
                 G4cerr << "Topas is exiting due to a serious error in geometry setup." << G4endl;
                 G4cerr << "Parameter " << name1 << " sets nucleus outside of cell." << G4endl;
                 exit(1);


### PR DESCRIPTION
This commit corrects the problem of wrong number and placement of mitochondria in the Ts*Cell classes as discussed in the topas-nbio forum (https://groups.google.com/forum/#!topic/topas-nbio-users/_XD2QcHURfk).
The assignment of a null pointer to pMito was replaced  by a call to 
"G4PhysicalVolumeStore::DeRegister(pMito);" 
when an overlap is detected.
Furthermore the placement check for the cell nucleus with the cell volume was corrected.