### PR TITLE
Bugfix: Not deleting overlapping substructures in cell geometries

### DIFF
--- a/geometry/cells/BloodCells/TsBasophil.cc
+++ b/geometry/cells/BloodCells/TsBasophil.cc
@@ -18,7 +18,7 @@
 #include "G4VPhysicalVolume.hh"
 
 #include "G4Orb.hh"
-
+#include "G4LogicalVolume.hh"
 #include "G4SystemOfUnits.hh"
 #include "G4PhysicalConstants.hh"
 #include "Randomize.hh"
@@ -115,34 +115,33 @@ G4VPhysicalVolume* TsBasophil::Construct()
         
         //Randomly distribute granules throughout cytoplasm volume
         for (int j = 0; j < NumberOfGranules; j++){
-                
-            G4bool Overlap = true;
-            while (Overlap == true){
-                    
+            auto OverlapCheck = true;
+            while (OverlapCheck)
+            {
                 G4double u = G4UniformRand()*2*pi;
                 G4double v = std::acos(2*G4UniformRand()-1);
                 G4double dr = G4UniformRand()*(BasophilRadius - NuclRadius);
                 G4double x = 0.0;
                 G4double y = 0.0;
                 G4double z = 0.0;
-                    
+                
                 x = (NuclRadius + dr)* std::cos(u) * std::sin(v);
                 y = (NuclRadius + dr)* std::sin(u) * std::sin(v);
                 z = (NuclRadius + dr)* std::cos(v);
-                    
+                
                 G4ThreeVector* position = new G4ThreeVector(x,y,z);
-            
+                
                 G4RotationMatrix* rotm = new G4RotationMatrix();
-            
+                
                 rotm->rotateX(0);
                 rotm->rotateY(0);
-            
+                
                 G4VPhysicalVolume* pGranule = CreatePhysicalVolume(subComponentName2, j, true, lGranule, rotm, position, fEnvelopePhys);
-            
+                
                 OverlapCheck = pGranule->CheckOverlaps();
-            
-                if (OverlapCheck == false){break;}
-                if (OverlapCheck == true){
+                
+                if (OverlapCheck == true) {
+                    fEnvelopePhys->GetLogicalVolume()->RemoveDaughter(pGranule);
                     pGranule = NULL;
                     G4cout << "**** Finding new position for volume " << subComponentName2 << ":" << j <<  " ****" << G4endl;
                 }

--- a/geometry/cells/BloodCells/TsEosinophil.cc
+++ b/geometry/cells/BloodCells/TsEosinophil.cc
@@ -18,7 +18,7 @@
 #include "G4VPhysicalVolume.hh"
 
 #include "G4Orb.hh"
-
+#include "G4LogicalVolume.hh"
 #include "G4SystemOfUnits.hh"
 #include "G4PhysicalConstants.hh"
 #include "Randomize.hh"
@@ -114,41 +114,40 @@ G4VPhysicalVolume* TsEosinophil::Construct()
     
         //Randomly distribute granules throughout cytoplasm volume
         for (int j = 0; j < NumberOfGranules; j++){
-        
-            G4bool Overlap = true;
-            while (Overlap == true){
-            
+            auto OverlapCheck = true;
+            while (OverlapCheck)
+            {
                 G4double u = G4UniformRand()*2*pi;
                 G4double v = std::acos(2*G4UniformRand()-1);
                 G4double dr = G4UniformRand()*(EosinophilRadius - NuclRadius);
-            
                 G4double x = 0.0;
                 G4double y = 0.0;
                 G4double z = 0.0;
-            
+                
                 x = (NuclRadius + dr)* std::cos(u) * std::sin(v);
                 y = (NuclRadius + dr)* std::sin(u) * std::sin(v);
                 z = (NuclRadius + dr)* std::cos(v);
-            
+                
                 G4ThreeVector* position = new G4ThreeVector(x,y,z);
-            
+                
                 G4RotationMatrix* rotm = new G4RotationMatrix();
-            
+                
                 rotm->rotateX(0);
                 rotm->rotateY(0);
-            
+                
                 G4VPhysicalVolume* pGranule = CreatePhysicalVolume(subComponentName2, j, true, lGranule, rotm, position, fEnvelopePhys);
-            
+                
                 OverlapCheck = pGranule->CheckOverlaps();
-            
-                if (OverlapCheck == false){break;}
-                if (OverlapCheck == true){
+                
+                if (OverlapCheck == true) {
+                    fEnvelopePhys->GetLogicalVolume()->RemoveDaughter(pGranule);
                     pGranule = NULL;
                     G4cout << "**** Finding new position for volume " << subComponentName2 << ":" << j <<  " ****" << G4endl;
                 }
             }
         }
     }
+    
 
     InstantiateChildren(fEnvelopePhys);
 	

--- a/geometry/cells/TsCuboidalCell.cc
+++ b/geometry/cells/TsCuboidalCell.cc
@@ -20,6 +20,7 @@
 #include "G4Box.hh"
 #include "G4Orb.hh"
 #include "G4Ellipsoid.hh"
+#include "G4LogicalVolume.hh"
 #include "G4SystemOfUnits.hh"
 #include "G4PhysicalConstants.hh"
 #include "Randomize.hh"
@@ -117,6 +118,7 @@ G4VPhysicalVolume* TsCuboidalCell::Construct()
     //*******************************
     // Subcomponent: Mitochondria
     //*******************************
+
     name = GetFullParmName("Mitochondria/NumberOfMitochondria");
     if (fPm->ParameterExists(name)) {
         
@@ -143,10 +145,9 @@ G4VPhysicalVolume* TsCuboidalCell::Construct()
         
         //Randomly distribute mitochondria throughout cell volume outside nucleus (default)
         for (int j = 0; j < NbOfMito; j++){
-            
-            G4bool Overlap = true;
-            while (Overlap == true){
-                
+            auto OverlapCheck = true;
+            while (OverlapCheck)
+            {
                 G4double u = G4UniformRand()*2*pi;
                 G4double v = std::acos(2*G4UniformRand()-1);
                 G4double dr = G4UniformRand()*(CellRadius - NucleusRadius);
@@ -169,16 +170,15 @@ G4VPhysicalVolume* TsCuboidalCell::Construct()
                 
                 G4VPhysicalVolume* pMito = CreatePhysicalVolume(subComponentName2, j, true, lMito, rotm, position, fEnvelopePhys);
                 
-                G4bool OverlapCheck = pMito->CheckOverlaps();
+                OverlapCheck = pMito->CheckOverlaps();
                 
-                if (OverlapCheck == false){break;}
-                if (OverlapCheck == true){
+                if (OverlapCheck == true) {
+                    fEnvelopePhys->GetLogicalVolume()->RemoveDaughter(pMito);
                     pMito = NULL;
                     G4cout << "**** Finding new position for volume " << subComponentName2 << ":" << j <<  " ****" << G4endl;
                 }
             }
         }
-        
     }
         
 

--- a/geometry/cells/TsEllipsoidCell.cc
+++ b/geometry/cells/TsEllipsoidCell.cc
@@ -19,6 +19,7 @@
 
 #include "G4Orb.hh"
 #include "G4Ellipsoid.hh"
+#include "G4LogicalVolume.hh"
 #include "G4SystemOfUnits.hh"
 #include "G4PhysicalConstants.hh"
 #include "Randomize.hh"
@@ -151,13 +152,13 @@ G4VPhysicalVolume* TsEllipsoidCell::Construct()
         
         //number of mitochondria
         const G4int NbOfMito  = fPm->GetIntegerParameter( GetFullParmName("Mitochondria/NumberOfMitochondria") );
-    
+        
         //Semi-axis lengths of the ellpsoid/mitochondria (default values if none are specified)
         G4double EllA = 0.5*micrometer;
         G4double EllB = 0.3*micrometer;
         G4double EllC = 0.9*micrometer;
         
-       name=GetFullParmName("Mitochondria/a");
+        name=GetFullParmName("Mitochondria/a");
         if (fPm->ParameterExists(name)){EllA = fPm->GetDoubleParameter(GetFullParmName("Mitochondria/a"), "Length" );}
         
         name=GetFullParmName("Mitochondria/b");
@@ -166,17 +167,15 @@ G4VPhysicalVolume* TsEllipsoidCell::Construct()
         name=GetFullParmName("Mitochondria/c");
         if (fPm->ParameterExists(name)){EllC = fPm->GetDoubleParameter(GetFullParmName("Mitochondria/c"), "Length" );}
         
-        
         G4String subComponentName2 = "Mitochondria";
         G4Ellipsoid* gMito = new G4Ellipsoid("gMito", EllA, EllB, EllC);
         G4LogicalVolume* lMito = CreateLogicalVolume(subComponentName2, gMito);
         
         //Randomly distribute mitochondria throughout cell volume
         for (int j = 0; j < NbOfMito; j++){
-            
-            G4bool Overlap = true;
-            while (Overlap == true){
-                
+            auto OverlapCheck = true;
+            while (OverlapCheck)
+            {
                 G4double u = G4UniformRand()*2*pi;
                 G4double v = std::acos(2*G4UniformRand()-1);
                 G4double dr = G4UniformRand()*(CellRadius - NuclRadius);
@@ -199,10 +198,10 @@ G4VPhysicalVolume* TsEllipsoidCell::Construct()
                 
                 G4VPhysicalVolume* pMito = CreatePhysicalVolume(subComponentName2, j, true, lMito, rotm, position, fEnvelopePhys);
                 
-                G4bool OverlapCheck = pMito->CheckOverlaps();
+                OverlapCheck = pMito->CheckOverlaps();
                 
-                if (OverlapCheck == false){break;}
-                if (OverlapCheck == true){
+                if (OverlapCheck == true) {
+                    fEnvelopePhys->GetLogicalVolume()->RemoveDaughter(pMito);
                     pMito = NULL;
                     G4cout << "**** Finding new position for volume " << subComponentName2 << ":" << j <<  " ****" << G4endl;
                 }

--- a/geometry/cells/TsFibroblastCell1.cc
+++ b/geometry/cells/TsFibroblastCell1.cc
@@ -22,6 +22,7 @@
 #include "G4ExtrudedSolid.hh"
 #include "G4Orb.hh"
 #include "G4Ellipsoid.hh"
+#include "G4LogicalVolume.hh"
 #include "G4SystemOfUnits.hh"
 #include "G4PhysicalConstants.hh"
 #include "Randomize.hh"
@@ -158,10 +159,9 @@ G4VPhysicalVolume* TsFibroblastCell1::Construct()
     
         //Randomly distribute mitochondria throughout cell volume outside nucleus (default)
         for (int j = 0; j < NbOfMito; j++){
-    
-            G4bool Overlap = true;
-            while (Overlap == true){
-        
+            auto OverlapCheck = true;
+            while (OverlapCheck)
+            {
                 G4double u = G4UniformRand()*2*pi;
                 G4double v = std::acos(2*G4UniformRand()-1);
                 G4double dr = G4UniformRand()*(CellRadius - NuclRadius);
@@ -170,11 +170,11 @@ G4VPhysicalVolume* TsFibroblastCell1::Construct()
                 G4double x = 0.0;
                 G4double y = 0.0;
                 G4double z = 0.0;
-    
+                
                 x = (NuclRadius + dr)* std::cos(u) * std::sin(v);
                 y = (NuclRadius + dr)* std::sin(u) * std::sin(v);
                 z = (NuclRadius + dr)* std::cos(v);
-
+                
                 G4ThreeVector* position = new G4ThreeVector(x,y,z);
                 
                 G4RotationMatrix* rotm = new G4RotationMatrix();
@@ -184,10 +184,10 @@ G4VPhysicalVolume* TsFibroblastCell1::Construct()
                 
                 G4VPhysicalVolume* pMito = CreatePhysicalVolume(subComponentName2, j, true, lMito, rotm, position, fEnvelopePhys);
                 
-                G4bool OverlapCheck = pMito->CheckOverlaps();
+                OverlapCheck = pMito->CheckOverlaps();
                 
-                if (OverlapCheck == false){break;}
-                if (OverlapCheck == true){
+                if (OverlapCheck == true) {
+                    fEnvelopePhys->GetLogicalVolume()->RemoveDaughter(pMito);
                     pMito = NULL;
                     G4cout << "**** Finding new position for volume " << subComponentName2 << ":" << j <<  " ****" << G4endl;
                 }

--- a/geometry/cells/TsFibroblastCell2.cc
+++ b/geometry/cells/TsFibroblastCell2.cc
@@ -21,6 +21,7 @@
 #include "G4ExtrudedSolid.hh"
 #include "G4Orb.hh"
 #include "G4Ellipsoid.hh"
+#include "G4LogicalVolume.hh"
 #include "G4SystemOfUnits.hh"
 #include "G4PhysicalConstants.hh"
 #include "Randomize.hh"
@@ -129,10 +130,9 @@ G4VPhysicalVolume* TsFibroblastCell2::Construct()
     
         //Randomly distribute mitochondria throughout cell volume outside nucleus (default)
         for (int j = 0; j < NbOfMito; j++){
-    
-            G4bool Overlap = true;
-            while (Overlap == true){
-        
+            auto OverlapCheck = true;
+            while (OverlapCheck)
+            {
                 G4double u = G4UniformRand()*2*pi;
                 G4double v = std::acos(2*G4UniformRand()-1);
                 G4double dr = G4UniformRand()*(CellRadius - NuclRadius);
@@ -141,11 +141,11 @@ G4VPhysicalVolume* TsFibroblastCell2::Construct()
                 G4double x = 0.0;
                 G4double y = 0.0;
                 G4double z = 0.0;
-    
+                
                 x = (NuclRadius + dr)* std::cos(u) * std::sin(v);
                 y = (NuclRadius + dr)* std::sin(u) * std::sin(v);
                 z = (NuclRadius + dr)* std::cos(v);
-
+                
                 G4ThreeVector* position = new G4ThreeVector(x,y,z);
                 
                 G4RotationMatrix* rotm = new G4RotationMatrix();
@@ -155,10 +155,10 @@ G4VPhysicalVolume* TsFibroblastCell2::Construct()
                 
                 G4VPhysicalVolume* pMito = CreatePhysicalVolume(subComponentName2, j, true, lMito, rotm, position, fEnvelopePhys);
                 
-                G4bool OverlapCheck = pMito->CheckOverlaps();
+                OverlapCheck = pMito->CheckOverlaps();
                 
-                if (OverlapCheck == false){break;}
-                if (OverlapCheck == true){
+                if (OverlapCheck == true) {
+                    fEnvelopePhys->GetLogicalVolume()->RemoveDaughter(pMito);
                     pMito = NULL;
                     G4cout << "**** Finding new position for volume " << subComponentName2 << ":" << j <<  " ****" << G4endl;
                 }

--- a/geometry/cells/TsFibroblastCell3.cc
+++ b/geometry/cells/TsFibroblastCell3.cc
@@ -21,6 +21,7 @@
 #include "G4ExtrudedSolid.hh"
 #include "G4Orb.hh"
 #include "G4Ellipsoid.hh"
+#include "G4LogicalVolume.hh"
 #include "G4SystemOfUnits.hh"
 #include "G4PhysicalConstants.hh"
 #include "Randomize.hh"
@@ -225,17 +226,15 @@ G4VPhysicalVolume* TsFibroblastCell3::Construct()
         name=GetFullParmName("Mitochondria/c");
         if (fPm->ParameterExists(name)){EllC = fPm->GetDoubleParameter(GetFullParmName("Mitochondria/c"), "Length" );}
         
-        
         G4String subComponentName2 = "Mitochondria";
         G4Ellipsoid* gMito = new G4Ellipsoid("gMito", EllA, EllB, EllC);
         G4LogicalVolume* lMito = CreateLogicalVolume(subComponentName2, gMito);
     
         //Randomly distribute mitochondria throughout cell volume outside nucleus (default)
         for (int j = 0; j < NbOfMito; j++){
-    
-            G4bool Overlap = true;
-            while (Overlap == true){
-        
+            auto OverlapCheck = true;
+            while (OverlapCheck)
+            {
                 G4double u = G4UniformRand()*2*pi;
                 G4double v = std::acos(2*G4UniformRand()-1);
                 G4double dr = G4UniformRand()*(CellRadius - NuclRadius);
@@ -244,11 +243,11 @@ G4VPhysicalVolume* TsFibroblastCell3::Construct()
                 G4double x = 0.0;
                 G4double y = 0.0;
                 G4double z = 0.0;
-    
+                
                 x = (NuclRadius + dr)* std::cos(u) * std::sin(v);
                 y = (NuclRadius + dr)* std::sin(u) * std::sin(v);
                 z = (NuclRadius + dr)* std::cos(v);
-
+                
                 G4ThreeVector* position = new G4ThreeVector(x,y,z);
                 
                 G4RotationMatrix* rotm = new G4RotationMatrix();
@@ -258,10 +257,10 @@ G4VPhysicalVolume* TsFibroblastCell3::Construct()
                 
                 G4VPhysicalVolume* pMito = CreatePhysicalVolume(subComponentName2, j, true, lMito, rotm, position, fEnvelopePhys);
                 
-                G4bool OverlapCheck = pMito->CheckOverlaps();
+                OverlapCheck = pMito->CheckOverlaps();
                 
-                if (OverlapCheck == false){break;}
-                if (OverlapCheck == true){
+                if (OverlapCheck == true) {
+                    fEnvelopePhys->GetLogicalVolume()->RemoveDaughter(pMito);
                     pMito = NULL;
                     G4cout << "**** Finding new position for volume " << subComponentName2 << ":" << j <<  " ****" << G4endl;
                 }

--- a/geometry/cells/TsHexagonCell.cc
+++ b/geometry/cells/TsHexagonCell.cc
@@ -22,6 +22,7 @@
 #include "G4ExtrudedSolid.hh"
 #include "G4Orb.hh"
 #include "G4Ellipsoid.hh"
+#include "G4LogicalVolume.hh"
 #include "G4SystemOfUnits.hh"
 #include "G4PhysicalConstants.hh"
 #include "Randomize.hh"
@@ -151,17 +152,15 @@ G4VPhysicalVolume* TsHexagonCell::Construct()
         name=GetFullParmName("Mitochondria/c");
         if (fPm->ParameterExists(name)){EllC = fPm->GetDoubleParameter(GetFullParmName("Mitochondria/c"), "Length" );}
         
-        
         G4String subComponentName2 = "Mitochondria";
         G4Ellipsoid* gMito = new G4Ellipsoid("gMito", EllA, EllB, EllC);
         G4LogicalVolume* lMito = CreateLogicalVolume(subComponentName2, gMito);
         
         //Randomly distribute mitochondria throughout cell volume
         for (int j = 0; j < NbOfMito; j++){
-            
-            G4bool Overlap = true;
-            while (Overlap == true){
-                
+            auto OverlapCheck = true;
+            while (OverlapCheck)
+            {
                 G4double u = G4UniformRand()*2*pi;
                 G4double v = std::acos(2*G4UniformRand()-1);
                 G4double dr = G4UniformRand()*(CellRadius - NuclRadius);
@@ -184,10 +183,10 @@ G4VPhysicalVolume* TsHexagonCell::Construct()
                 
                 G4VPhysicalVolume* pMito = CreatePhysicalVolume(subComponentName2, j, true, lMito, rotm, position, fEnvelopePhys);
                 
-                G4bool OverlapCheck = pMito->CheckOverlaps();
+                OverlapCheck = pMito->CheckOverlaps();
                 
-                if (OverlapCheck == false){break;}
-                if (OverlapCheck == true){
+                if (OverlapCheck == true) {
+                    fEnvelopePhys->GetLogicalVolume()->RemoveDaughter(pMito);
                     pMito = NULL;
                     G4cout << "**** Finding new position for volume " << subComponentName2 << ":" << j <<  " ****" << G4endl;
                 }

--- a/geometry/cells/TsSphericalCell.cc
+++ b/geometry/cells/TsSphericalCell.cc
@@ -19,6 +19,7 @@
 
 #include "G4Orb.hh"
 #include "G4Ellipsoid.hh"
+#include "G4LogicalVolume.hh"
 #include "G4SystemOfUnits.hh"
 #include "G4PhysicalConstants.hh"
 #include "Randomize.hh"
@@ -156,10 +157,9 @@ G4VPhysicalVolume* TsSphericalCell::Construct()
         
         //Randomly distribute mitochondria throughout cell volume
         for (int j = 0; j < NbOfMito; j++){
-                
-            G4bool Overlap = true;
-            while (Overlap == true){
-                    
+            auto OverlapCheck = true;
+            while (OverlapCheck)
+            {
                 G4double u = G4UniformRand()*2*pi;
                 G4double v = std::acos(2*G4UniformRand()-1);
                 G4double dr = G4UniformRand()*(CellRadius - NuclRadius);
@@ -168,11 +168,11 @@ G4VPhysicalVolume* TsSphericalCell::Construct()
                 G4double x = 0.0;
                 G4double y = 0.0;
                 G4double z = 0.0;
-                    
+                
                 x = (NuclRadius + dr)* std::cos(u) * std::sin(v);
                 y = (NuclRadius + dr)* std::sin(u) * std::sin(v);
                 z = (NuclRadius + dr)* std::cos(v);
-                    
+                
                 G4ThreeVector* position = new G4ThreeVector(x,y,z);
                 
                 G4RotationMatrix* rotm = new G4RotationMatrix();
@@ -182,10 +182,10 @@ G4VPhysicalVolume* TsSphericalCell::Construct()
                 
                 G4VPhysicalVolume* pMito = CreatePhysicalVolume(subComponentName2, j, true, lMito, rotm, position, fEnvelopePhys);
                 
-                G4bool OverlapCheck = pMito->CheckOverlaps();
+                OverlapCheck = pMito->CheckOverlaps();
                 
-                if (OverlapCheck == false){break;}
-                if (OverlapCheck == true){
+                if (OverlapCheck == true) {
+                    fEnvelopePhys->GetLogicalVolume()->RemoveDaughter(pMito);
                     pMito = NULL;
                     G4cout << "**** Finding new position for volume " << subComponentName2 << ":" << j <<  " ****" << G4endl;
                 }


### PR DESCRIPTION
**Describe the bug**
When adding e.g. mitochondria to a cell those that overlap with the nucleus are not being removed. The loop generating the volumes creates another volume with same copy id and name but in a different place. The original, overlapping volume is still present.

**To Reproduce**
Steps to reproduce the behavior:
```
d:Ge/World/HLX = 50 um
d:Ge/World/HLY = 50 um
d:Ge/World/HLZ = 50 um

s:Ge/SphericalCell/Type = "TsSphericalCell"
s:Ge/SphericalCell/Parent = "World"
d:Ge/SphericalCell/CellRadius = 20 um
s:Ge/SphericalCell/Material = "G4_WATER"
d:Ge/SphericalCell/Nucleus/NucleusRadius = 5. um
s:Ge/SphericalCell/Nucleus/Material = "G4_WATER"
s:Ge/SphericalCell/Nucleus/Color = "Red"

i:Ge/SphericalCell/Mitochondria/NumberOfMitochondria = 1
s:Ge/SphericalCell/Mitochondria/Material = "G4_WATER"
s:Ge/SphericalCell/Mitochondria/Color = "green"

s:Gr/Graphics/Type = "OpenGL"
Ts/UseQt = "True"
```

**Expected behavior**
Overlapping volume is deleted from parent when overlap is found before while-loop continues.

**Screenshots / Output BEFORE**
<img width="1266" alt="TOPAS_nBio_Mitochondria" src="https://user-images.githubusercontent.com/7443659/119551679-e53a0c80-bd67-11eb-9a55-6daa767ad67e.png">

** Screenshots AFTER **
<img width="1277" alt="TOPAS_nBio_Mitochondria_Fixed" src="https://user-images.githubusercontent.com/7443659/119551726-f5ea8280-bd67-11eb-8a6a-9831c6cd4105.png">

Fixed this for Cells (Spherical, Cuboidal, Ellipsoid, Fibroblast, Hexagon) and for granules in Basophils and Eosinophils.