### PR TITLE
fix: verify that process != nullptr

### DIFF
--- a/processes/TsEmDNAChemistry.cc
+++ b/processes/TsEmDNAChemistry.cc
@@ -609,7 +609,7 @@ void TsEmDNAChemistry::ConstructProcess()
     }
     
     process = G4ProcessTable::GetProcessTable()->FindProcess("e-_G4DNAElectronSolvation", "e-");
-    if ( process == nullptr ) {
+    if ( process != nullptr ) {
         G4DNAElectronSolvation* solvation = (G4DNAElectronSolvation*)process;
         G4VEmModel* solvationModel = new G4DNAOneStepThermalizationModel();
         solvation->SetEmModel(solvationModel, 0);

--- a/processes/TsEmDNAChemistryExtended.cc
+++ b/processes/TsEmDNAChemistryExtended.cc
@@ -656,7 +656,7 @@ void TsEmDNAChemistryExtended::ConstructProcess()
     }
     
     process = G4ProcessTable::GetProcessTable()->FindProcess("e-_G4DNAElectronSolvation", "e-");
-    if ( process == nullptr ) {
+    if ( process != nullptr ) {
         G4DNAElectronSolvation* solvation = (G4DNAElectronSolvation*)process;
         G4VEmModel* solvationModel = new G4DNAOneStepThermalizationModel();
         solvation->SetEmModel(solvationModel, 0);


### PR DESCRIPTION
In `TsEmDNAChemistry::ConstructProcess`, specifically, lines 611-616,
```
    process = G4ProcessTable::GetProcessTable()->FindProcess("e-_G4DNAElectronSolvation", "e-");
    if ( process == nullptr ) {
        G4DNAElectronSolvation* solvation = (G4DNAElectronSolvation*)process;
        G4VEmModel* solvationModel = new G4DNAOneStepThermalizationModel();
        solvation->SetEmModel(solvationModel, 0);
    }
```
the condition should be checking if the process is not a null pointer, similar to the block before.
The same is found in `TsEmDNAChemistryExtended`.